### PR TITLE
[TYPO] UN agrees to change Turkey’s official name to ‘Türkiye’ at 202…

### DIFF
--- a/src/I18N/Country.php
+++ b/src/I18N/Country.php
@@ -5014,21 +5014,21 @@ class Country
 
 
     /**
-     * ISO 3166-1 Alpha-2 code of Turkey
+     * ISO 3166-1 Alpha-2 code of Türkiye
      *
      * @var string
      */
     public const ALPHA_2_CODE_TR = 'TR';
 
     /**
-     * ISO 3166-1 Alpha-3 code of Turkey
+     * ISO 3166-1 Alpha-3 code of Türkiye
      *
      * @var string
      */
     public const ALPHA_3_CODE_TR = 'TUR';
 
     /**
-     * ISO 3166-1 numeric code of Turkey
+     * ISO 3166-1 numeric code of Türkiye
      *
      * @var int
      */

--- a/src/I18N/Currency.php
+++ b/src/I18N/Currency.php
@@ -9928,7 +9928,7 @@ class Currency
      * ISO-4217 Code for the Turkish lira
      *
      * Countries:
-     * - Turkey
+     * - Türkiye
      *
      * @var string
      */


### PR DESCRIPTION
UN agrees to change Turkey’s official name to ‘Türkiye’ at 2022-06-02